### PR TITLE
fix: don't modify self.params in NetFileClient

### DIFF
--- a/netfile_client/NetFileClient.py
+++ b/netfile_client/NetFileClient.py
@@ -195,7 +195,7 @@ class NetFileClient:
     def fetch(self, endpoint, **kwargs):
         """ Fetch all of a particular record type """
         url = self._base_url + getattr(Routes, endpoint)
-        params = self._params
+        params = { **self._params }
         if 'params' in kwargs:
             params.update(kwargs['params'])
         res = self.session.get(url, auth=self._auth, params=params)


### PR DESCRIPTION
This fixes a bug with NetFileClient that was causing it to not start at the first page of results when the client was used repeatedly to fetch from different endpoints.